### PR TITLE
Limit curve fitting runtime with lsqcurvefit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,25 @@
-MainPulsePropagation_04_HHG_Ar1plus_808_10nm_01.m is the source code. 
+MainPulsePropagation_04_HHG_Ar1plus_808_10nm_01.m is the source code.
 
 Library functions in the branch
 analysis directory: 1 function (main_pulse_propagation)
 
 theory directory: 12 functions
-(CapillaryAttenuationCoefficient, ElectricField_d, GroupVelocityDispersion, HHG_DipolePhase, InverseBremsstrahlungCoefficient, IonizationTime_long, IonizationTime_short, RecombinationTime, StaticIonizationRate, ThomsonScatteringCoefficient, TunnelingIonizationRate_Linear, TunnelingIonizationRate_Linear2)
+(CapillaryAttenuationCoefficient, ElectricField_d, GroupVelocityDispersion,
+ HHG_DipolePhase, InverseBremsstrahlungCoefficient, IonizationTime_long,
+ IonizationTime_short, RecombinationTime, StaticIonizationRate,
+ ThomsonScatteringCoefficient, TunnelingIonizationRate_Linear,
+ TunnelingIonizationRate_Linear2)
+
+### Runtime-limited curve fitting
+
+The `main_pulse_propagation` function and the source script now use
+`timed_lsqcurvefit`, a wrapper around `lsqcurvefit` configured with
+`optimoptions` limits. Optional parameters control the fitting process:
+
+- `maxIterations` – maximum solver iterations
+- `maxFunctionEvaluations` – maximum function evaluations
+- `maxTime` – timeout in seconds (default 120)
+- `downsampleFactor` – use every N-th data point
+
+These parameters allow data to be pre-filtered and fitting to terminate
+automatically when limits are exceeded.

--- a/analysis/HHG_Capillary/main_pulse_propagation.m
+++ b/analysis/HHG_Capillary/main_pulse_propagation.m
@@ -1,4 +1,17 @@
-function main_pulse_propagation
+function main_pulse_propagation(maxIterations, maxFunctionEvaluations, maxTime, downsampleFactor)
+%MAIN_PULSE_PROPAGATION Propagate the main pulse in a capillary waveguide.
+%   MAIN_PULSE_PROPAGATION(MAXITER, MAXFUNEVAL, MAXTIME, DOWNSAMPLE) allows
+%   control over the curve fitting routine used throughout the simulation.
+%   MAXITER and MAXFUNEVAL set the limits for the optimisation routine,
+%   MAXTIME defines a timeout in seconds (default 120 s) and DOWNSAMPLE
+%   reduces the number of data points used in fitting by taking every
+%   DOWNSAMPLE-th sample. These parameters are optional.
+
+    if nargin < 1 || isempty(maxIterations),          maxIterations = 400; end
+    if nargin < 2 || isempty(maxFunctionEvaluations), maxFunctionEvaluations = 800; end
+    if nargin < 3 || isempty(maxTime),                maxTime = 120; end
+    if nargin < 4 || isempty(downsampleFactor),       downsampleFactor = 1; end
+
     addpath(fullfile(fileparts(mfilename('fullpath')), '..', 'theory'));
 % MainPulsePropagation_HHG.m
 %  Part I:
@@ -415,82 +428,83 @@ for qq = 1 : 1
                     
 
 % Curve fitting
-   % peak electric field (cfit object) E_peak_cfit(z)
-   % This is a cfit object, which can be used as a function:
-   %    E_peak = E_peak_cfit(z),
-   E_peak_cfit = fit(z',E_peak','exp1');   % unit: V/m 
-   
-   % peak laser intensity (cfit object) I_peak_cfit
-   % This is a cfit object, which can be used as a function:
-   %    I_peak = I_peak_cfit(z),
-   I_peak_cfit = fit(z',I_peak','exp1');   % unit: W/m^2
-   
-   % pulse duration (cfit object) tau_cfit
-   tau_cfit = fit(z',(tau/fs)','poly3');   % unit: fs
-   tau_fun = @(z) tau_cfit(z)*fs;         % unit: sec 
+   fitArgs = {'MaxIterations', maxIterations, ...
+              'MaxFunctionEvaluations', maxFunctionEvaluations, ...
+              'MaxTime', maxTime, ...
+              'Downsample', downsampleFactor};
 
-   % electron density (cfit object) N_e_cfit(z)
-   N_e_cfit = fit(z',N_e','poly3');        % unit: m^-3
-   
-   % accumulated GDD (cfit object) D_cfit(z)
-   D_cfit = fit(z',(D/fs^2)','poly3');     % unit: fs^2
-   D_fun = @(z) D_cfit(z)*fs^2;            % unit: s^2
-   
-   % plasma refractive index of the driving pulse (cfit object) n_plasma_cfit(z)
-   n_plasma_d_cfit = fit(z',n_plasma_d','poly3');
-   
-   % accumulated group delay (cfit object) C_cfit(z)
-   C_cfit = fit(z',(C/fs)','poly3');       % unit: fs
-   C_fun = @(z) C_cfit(z)*fs;              % unit: sec
-   
+   % peak electric field E_peak_cfit(z)
+   E_peak_cfit = timed_lsqcurvefit(z, E_peak, 'exp1', fitArgs{:});   % unit: V/m
+
+   % peak laser intensity I_peak_cfit
+   I_peak_cfit = timed_lsqcurvefit(z, I_peak, 'exp1', fitArgs{:});   % unit: W/m^2
+
+   % pulse duration tau_cfit
+   tau_cfit = timed_lsqcurvefit(z, (tau/fs), 'poly3', fitArgs{:});   % unit: fs
+   tau_fun = @(zz) tau_cfit(zz)*fs;       % unit: sec
+
+   % electron density N_e_cfit(z)
+   N_e_cfit = timed_lsqcurvefit(z, N_e, 'poly3', fitArgs{:});        % unit: m^-3
+
+   % accumulated GDD D_cfit(z)
+   D_cfit = timed_lsqcurvefit(z, (D/fs^2), 'poly3', fitArgs{:});     % unit: fs^2
+   D_fun = @(zz) D_cfit(zz)*fs^2;        % unit: s^2
+
+   % plasma refractive index of the driving pulse n_plasma_cfit(z)
+   n_plasma_d_cfit = timed_lsqcurvefit(z, n_plasma_d, 'poly3', fitArgs{:});
+
+   % accumulated group delay C_cfit(z)
+   C_cfit = timed_lsqcurvefit(z, (C/fs), 'poly3', fitArgs{:});       % unit: fs
+   C_fun = @(zz) C_cfit(zz)*fs;          % unit: sec
+
    % total wavenumber of the driving pulse k_d_total_cfit(z)
-   k_d_total_cfit = fit(z',k_d_total','poly3');    % unit: 1/m
+   k_d_total_cfit = timed_lsqcurvefit(z, k_d_total, 'poly3', fitArgs{:});    % unit: 1/m
    
    % accumulated phase shift of the driving pulse due to propagation (rad)
-   phi_d_prop_cfit = fit(z',phi_d_prop','poly3');    % unit: rad
+   phi_d_prop_cfit = timed_lsqcurvefit(z, phi_d_prop, 'poly3', fitArgs{:});    % unit: rad
 
    % phase velocity of the driving pulse v_d_cfit(z)
-   v_d_cfit = fit(z',v_d','poly3');    % unit: m/sec
+   v_d_cfit = timed_lsqcurvefit(z, v_d, 'poly3', fitArgs{:});    % unit: m/sec
 
    if FigureSwitch
       figure;
-      subplot(4,3,1),  plot(E_peak_cfit,z,E_peak),
+      subplot(4,3,1),  plot(z,E_peak_cfit(z),z,E_peak),
                        ylabel('E_{peak} (V/m)');
                        xlabel('position z (m)');
                        title('peak electric field');
-      subplot(4,3,4),  plot(I_peak_cfit,z,I_peak),
+      subplot(4,3,4),  plot(z,I_peak_cfit(z),z,I_peak),
                        ylabel('I_{peak} (W/m^2)');
                        xlabel('position z (m)');
                        title('peak intensity');
-      subplot(4,3,7),  plot(N_e_cfit,z,N_e),
+      subplot(4,3,7),  plot(z,N_e_cfit(z),z,N_e),
                        ylabel('N_e (m^{-3})');
                        xlabel('position z (m)');
                        title('electron density');
-      subplot(4,3,2),  plot(n_plasma_d_cfit,z,n_plasma_d),
+      subplot(4,3,2),  plot(z,n_plasma_d_cfit(z),z,n_plasma_d),
                        ylabel('n_{plasma}');
                        xlabel('position z (m)');
                        title('plasma refractive index');
-      subplot(4,3,5),  plot(D_cfit,z,D/fs^2),
+      subplot(4,3,5),  plot(z,D_cfit(z),z,D/fs^2),
                        ylabel('D (fs^2)');
                        xlabel('position z (m)');
                        title('group-delay-dispersion (GDD)');
-      subplot(4,3,8),  plot(tau_cfit,z,tau/fs),
+      subplot(4,3,8),  plot(z,tau_cfit(z),z,tau/fs),
                        ylabel('\tau (fs)');
                        xlabel('position z (m)');
                        title('pulse duration');
-      subplot(4,3,11),  plot(C_cfit,z,C/fs),
+      subplot(4,3,11),  plot(z,C_cfit(z),z,C/fs),
                        ylabel('C (fs)');
                        xlabel('position z (m)');
                        title('group delay');
-      subplot(4,3,3),  plot(k_d_total_cfit,z,k_d_total),
+      subplot(4,3,3),  plot(z,k_d_total_cfit(z),z,k_d_total),
                        ylabel('k_{d\_total}(z) (1/m)');
                        xlabel('position z (m)');
                        title('total wavenumber');
-      subplot(4,3,6),  plot(phi_d_prop_cfit,z,phi_d_prop),
+      subplot(4,3,6),  plot(z,phi_d_prop_cfit(z),z,phi_d_prop),
                        ylabel('\phi_{d\_prop}(z) (rad)');
                        xlabel('position z (m)');
                        title('accumulated phase due to propagation');
-      subplot(4,3,9),  plot(v_d_cfit,z,v_d),
+      subplot(4,3,9),  plot(z,v_d_cfit(z),z,v_d),
                        ylabel('v_d (m/sec)');
                        xlabel('position z (m)');
                        title('phase velocity');
@@ -535,23 +549,23 @@ for qq = 1 : 1
    alpha_s(N_dipole) = 2*alpha_s(N_dipole-1) - alpha_s(N_dipole-2);
    
 % curve fitting of the dipole phase and the alpha coefficient
-   Phi_dipole_l_cfit = fit(I_dipole',Phi_dipole_l','fourier3');  % unit: rad
-   Phi_dipole_s_cfit = fit(I_dipole',Phi_dipole_s','power2');    % unit: rad
-   alpha_l_cfit = fit(I_dipole',alpha_l','poly5');       % unit: m^2/W
-   alpha_s_cfit = fit(I_dipole',alpha_s','poly5');       % unit: m^2/W
+   Phi_dipole_l_cfit = timed_lsqcurvefit(I_dipole, Phi_dipole_l, 'fourier3', fitArgs{:});  % unit: rad
+   Phi_dipole_s_cfit = timed_lsqcurvefit(I_dipole, Phi_dipole_s, 'power2', fitArgs{:});    % unit: rad
+   alpha_l_cfit = timed_lsqcurvefit(I_dipole, alpha_l, 'poly5', fitArgs{:});       % unit: m^2/W
+   alpha_s_cfit = timed_lsqcurvefit(I_dipole, alpha_s, 'poly5', fitArgs{:});       % unit: m^2/W
    
    if FigureSwitch
    figure;
-   subplot(1,4,1), plot(Phi_dipole_l_cfit,I_dipole,Phi_dipole_l);
+   subplot(1,4,1), plot(I_dipole,Phi_dipole_l_cfit(I_dipole),I_dipole,Phi_dipole_l);
       xlabel('intensity (W/m^2)'), ylabel('\Phi_{dipole\_long} (rad)');
       title('long-trajectory dipole phase');
-   subplot(1,4,2), plot(Phi_dipole_s_cfit,I_dipole,Phi_dipole_s);
+   subplot(1,4,2), plot(I_dipole,Phi_dipole_s_cfit(I_dipole),I_dipole,Phi_dipole_s);
       xlabel('intensity (W/m^2)'), ylabel('\Phi_{dipole\_short} (rad)');
       title('short-trajectory dipole phase');
-   subplot(1,4,3), plot(alpha_l_cfit,I_dipole,alpha_l);
+   subplot(1,4,3), plot(I_dipole,alpha_l_cfit(I_dipole),I_dipole,alpha_l);
       xlabel('intensity (W/cm^2)'), ylabel('\alpha_{long} (m^2/W)');
       title('long-trajectory \alpha');
-   subplot(1,4,4), plot(alpha_s_cfit,I_dipole,alpha_s);
+   subplot(1,4,4), plot(I_dipole,alpha_s_cfit(I_dipole),I_dipole,alpha_s);
       xlabel('intensity (W/cm^2)'), ylabel('\alpha_{short} (m^2/W)');
       title('short-trajectory \alpha');
    sgtitle('Dipole phase calculation');

--- a/analysis/HHG_Capillary/timed_lsqcurvefit.m
+++ b/analysis/HHG_Capillary/timed_lsqcurvefit.m
@@ -1,0 +1,68 @@
+function fitFcn = timed_lsqcurvefit(x, y, fitType, varargin)
+%TIMED_LSQCURVEFIT Fit data with runtime limits.
+%   FITFCN = TIMED_LSQCURVEFIT(X, Y, FITTYPE) fits the data (X,Y) using
+%   LSQCURVEFIT with a model specified by FITTYPE. The function returns a
+%   function handle FITFCN that evaluates the fitted model at new query
+%   points. Additional name-value pairs control the solver:
+%       'MaxIterations'          - maximum number of iterations
+%       'MaxFunctionEvaluations' - maximum number of function evaluations
+%       'MaxTime'                - maximum runtime in seconds
+%       'Downsample'             - use every N-th point from the data
+%
+%   Supported FITTYPE strings: 'exp1', 'poly3', 'poly5', 'power2',
+%   and 'fourier3'.
+%
+%   Example:
+%       f = timed_lsqcurvefit(x, y, 'poly3', 'MaxTime', 60);
+%       yfit = f(x);
+%
+%   This utility requires the Optimization Toolbox.
+
+p = inputParser;
+addParameter(p, 'MaxIterations', 400);
+addParameter(p, 'MaxFunctionEvaluations', 800);
+addParameter(p, 'MaxTime', 120);
+addParameter(p, 'Downsample', 1);
+parse(p, varargin{:});
+
+x = x(:);  % ensure column
+y = y(:);
+
+% Downsample data if requested
+if p.Results.Downsample > 1
+    x = x(1:p.Results.Downsample:end);
+    y = y(1:p.Results.Downsample:end);
+end
+
+switch fitType
+    case 'exp1'
+        model = @(c, xdata) c(1) .* exp(c(2) .* xdata);
+        c0 = [y(1); 0];
+    case 'poly3'
+        model = @(c, xdata) polyval(c, xdata);
+        c0 = zeros(4,1);
+    case 'poly5'
+        model = @(c, xdata) polyval(c, xdata);
+        c0 = zeros(6,1);
+    case 'power2'
+        model = @(c, xdata) c(1) .* xdata.^c(2) + c(3);
+        c0 = [1; 1; 0];
+    case 'fourier3'
+        model = @(c, xdata) c(1) + ...
+            c(2).*cos(xdata.*c(8)) + c(3).*sin(xdata.*c(8)) + ...
+            c(4).*cos(2*xdata.*c(8)) + c(5).*sin(2*xdata.*c(8)) + ...
+            c(6).*cos(3*xdata.*c(8)) + c(7).*sin(3*xdata.*c(8));
+        c0 = zeros(8,1); c0(8) = 1;
+    otherwise
+        error('timed_lsqcurvefit:UnsupportedType', 'Unsupported fit type %s', fitType);
+end
+
+options = optimoptions('lsqcurvefit', ...
+    'MaxIterations', p.Results.MaxIterations, ...
+    'MaxFunctionEvaluations', p.Results.MaxFunctionEvaluations, ...
+    'MaxTime', p.Results.MaxTime);
+
+coeff = lsqcurvefit(model, c0, x, y, [], [], options);
+fitFcn = @(xquery) model(coeff, xquery);
+end
+

--- a/source codes/HHG_MainPulsePropagation_Capillary/timed_lsqcurvefit.m
+++ b/source codes/HHG_MainPulsePropagation_Capillary/timed_lsqcurvefit.m
@@ -1,0 +1,68 @@
+function fitFcn = timed_lsqcurvefit(x, y, fitType, varargin)
+%TIMED_LSQCURVEFIT Fit data with runtime limits.
+%   FITFCN = TIMED_LSQCURVEFIT(X, Y, FITTYPE) fits the data (X,Y) using
+%   LSQCURVEFIT with a model specified by FITTYPE. The function returns a
+%   function handle FITFCN that evaluates the fitted model at new query
+%   points. Additional name-value pairs control the solver:
+%       'MaxIterations'          - maximum number of iterations
+%       'MaxFunctionEvaluations' - maximum number of function evaluations
+%       'MaxTime'                - maximum runtime in seconds
+%       'Downsample'             - use every N-th point from the data
+%
+%   Supported FITTYPE strings: 'exp1', 'poly3', 'poly5', 'power2',
+%   and 'fourier3'.
+%
+%   Example:
+%       f = timed_lsqcurvefit(x, y, 'poly3', 'MaxTime', 60);
+%       yfit = f(x);
+%
+%   This utility requires the Optimization Toolbox.
+
+p = inputParser;
+addParameter(p, 'MaxIterations', 400);
+addParameter(p, 'MaxFunctionEvaluations', 800);
+addParameter(p, 'MaxTime', 120);
+addParameter(p, 'Downsample', 1);
+parse(p, varargin{:});
+
+x = x(:);  % ensure column
+y = y(:);
+
+% Downsample data if requested
+if p.Results.Downsample > 1
+    x = x(1:p.Results.Downsample:end);
+    y = y(1:p.Results.Downsample:end);
+end
+
+switch fitType
+    case 'exp1'
+        model = @(c, xdata) c(1) .* exp(c(2) .* xdata);
+        c0 = [y(1); 0];
+    case 'poly3'
+        model = @(c, xdata) polyval(c, xdata);
+        c0 = zeros(4,1);
+    case 'poly5'
+        model = @(c, xdata) polyval(c, xdata);
+        c0 = zeros(6,1);
+    case 'power2'
+        model = @(c, xdata) c(1) .* xdata.^c(2) + c(3);
+        c0 = [1; 1; 0];
+    case 'fourier3'
+        model = @(c, xdata) c(1) + ...
+            c(2).*cos(xdata.*c(8)) + c(3).*sin(xdata.*c(8)) + ...
+            c(4).*cos(2*xdata.*c(8)) + c(5).*sin(2*xdata.*c(8)) + ...
+            c(6).*cos(3*xdata.*c(8)) + c(7).*sin(3*xdata.*c(8));
+        c0 = zeros(8,1); c0(8) = 1;
+    otherwise
+        error('timed_lsqcurvefit:UnsupportedType', 'Unsupported fit type %s', fitType);
+end
+
+options = optimoptions('lsqcurvefit', ...
+    'MaxIterations', p.Results.MaxIterations, ...
+    'MaxFunctionEvaluations', p.Results.MaxFunctionEvaluations, ...
+    'MaxTime', p.Results.MaxTime);
+
+coeff = lsqcurvefit(model, c0, x, y, [], [], options);
+fitFcn = @(xquery) model(coeff, xquery);
+end
+


### PR DESCRIPTION
## Summary
- Replace `fit` with new `timed_lsqcurvefit` helper using `lsqcurvefit` and `optimoptions` limits
- Add optional runtime/iteration/downsampling parameters to `main_pulse_propagation` and source script
- Document tuning parameters in README and pre-filter data by downsampling

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeadf08c20833192d84a94d10b8cbb